### PR TITLE
v1.1.0

### DIFF
--- a/substitutions/ts_folderAssignments.txt
+++ b/substitutions/ts_folderAssignments.txt
@@ -1,0 +1,28 @@
+// This custom substitution setup allows you to map the name of the folder your files are in to the names of your subjects.					
+// The suggested usage of this is for photoshoots. For each subject you are photographing, change your camera settings to put their photos in different folders. This substitution file will then let you quickly type their names.					
+// For example, if your photos of Miss Terry are in a folder beginning with "102", you can type [[pfirst]] in one of the photo's metadata fields to have it replaced with "Miss"					
+					
+// fldrnum grabs the first 3 characters of the folder this file is in. The "3" can be changed to increase or decrease the amount of the filename to grab.					
+fldrnum	[[fprefix;[[mfolder]];3]]				
+					
+// Using enumerated replacements to grab the column they are associated with.					
+pname	[[fn[[fldrnum]]#1]]				
+pfirst	[[fn[[fldrnum]]#2]]				
+plast	[[fn[[fldrnum]]#3]]				
+pnum	[[fn[[fldrnum]]#4]]				
+ppos	[[fn[[fldrnum]]#5]]				
+					
+// Data table - the folder nums are prefixed with "fn" to avoid any potential conflicts with other custom substitutions.					
+// folder num	Full Name (#1)	First Name (#2)	Last Name (#3)	Number (#4)	Position (#5)
+fn100	Apple Banana	Apple	Banana	44	Defense
+fn101	Milk Shake	Milk	Shake	12	Striker
+fn102	Miss Terry	Miss	Terry	00	Investigator
+fn103					
+fn104					
+fn105					
+fn106					
+fn107					
+fn108					
+fn109					
+fn110					
+					

--- a/substitutions/ts_hotCodes.txt
+++ b/substitutions/ts_hotCodes.txt
@@ -1,0 +1,39 @@
+// This substitution file allows you to mimic the behavior of Photo Mechanic's "hot codes" feature.			
+// When one of the column titles is used as a substitution, the lookups are used to identify which row the data should be grabbed from.			
+// Lookups are searched in the order specified.			
+// For example, if you type [[cname]], this substitution will first check to see if the camera's serial number is listed in the data table. If it is, the first match will be used. Otherwise, the model of the camera will be checked. If the camera model does not match a row, then the "Creator" metadata field will be checked. FInally if no matches can be found, "UNKNOWN" will be used.			
+// This substitution file uses a large amount of recursions - if you get an error, you may want to increase the recursion limit in the script preferences.			
+			
+// COLUMN TITLES - using one of these as a substitution will grab that column in the row identified by the lookups above.			
+cname	[[[[hclogic]]#1]]		
+clast	[[[[hclogic]]#2]]		
+cpos	[[[[hclogic]]#3]]		
+			
+			
+			
+// LOOKUPS - the result of these are looked up in the table below			
+lkup1	[[cserial]]		
+lkup2	[[ccamera]]		
+lkup3	[[mcreator]]		
+lkup4			
+lkup5			
+lkup6			
+lkup7			
+lkup8			
+lkup9			
+lkup10			
+// if you add more than 10 lookups, you will need to add them to hcselector: 			
+hcselector	[[fsafe;[[lkup1]];[[lkup2]];[[lkup3]];[[lkup4]];[[lkup5]];[[lkup6]];[[lkup7]];[[lkup8]];[[lkup9]];[[lkup10]]]]		
+// hclogic uses fbranch to first check if hcselector identifies any valid substitutions (it will return an empty string if none are identified). If any are identified, fbranch passes the result of hcselector. Otherwise, it passes "??UKN??".			
+hclogic	[[fbranch;[[hcselector]];[[hcselector]];??UKN??]]		
+			
+			
+// DATA TABLE			
+// Photog info:	Name (#1)	Last Name (#2)	Position (#3)
+3004849	Pluto Polaris	Polaris	Photographer
+3027706	Jason Bates	Bates	Media Specialist III
+Canon EOS 77D	Gordon Yonel	Yonel	Stringer
+Dash Zach	Dash Zach	Zach	Photographer
+			
+??UKN??	UNKNOWN	UNKNOWN	UNKNOWN
+// Default substitution. If no lookups match, this is used.			

--- a/substitutions/ts_photoMechanicVariables.txt
+++ b/substitutions/ts_photoMechanicVariables.txt
@@ -1,12 +1,11 @@
-// ts_photoMechanicVariables.txt
-// A Custom Substitution list for the Text Substitutions Bridge Script
-//
-// This list aliases PM's variable names to the built-in substitutions.
-// This list also assumes that, for maximum PM compatability, you have changed the script's preferences to
-// the {single bracket} option. If you wish to use a different delimiter, you will need to find and replace 
-// the brackets in this file.
-
-// Image-specific
+// ts_photoMechanicVariables.txt	
+// A Custom Substitution list for the Text Substitutions Bridge Script	
+//	
+// This list aliases PM's variable names to the built-in substitutions.	
+// This list also assumes that, for maximum PM compatability, you have changed the script's preferences to	
+// the {single bracket} option. If you wish to use a different delimiter, you will need to find and replace 	
+// the brackets in this file.	
+// Image-specific	
 aperture	{cf}
 f	{cf}
 filename	{mname}
@@ -15,7 +14,7 @@ filenamebase	{mnameshort}
 fbas	{mnameshort}
 focallength	{czoom}
 folder	{mfolder}
-mldr	{mfolder}
+fldr	{mfolder}
 height	{ch}
 h	{ch}
 y	{ch}
@@ -38,8 +37,10 @@ ss	{css}
 width	{cw}
 w	{cw}
 h	{ch}
+prefix	{fbranch;{feq;{fprefix;{mname};1};_};{fsubstr;{mnameshort};1;4};{fprefix;{mnameshort};3}}
+pfx	{fbranch;{feq;{fprefix;{mname};1};_};{fsubstr;{mnameshort};1;4};{fprefix;{mnameshort};3}}
 
-// IPTC fields
+// IPTC fields	
 city	{mcity}
 country	{mcountry}
 cnty	{mcountry}
@@ -51,8 +52,40 @@ location	{msublocation}
 loc	{msublocation}
 state	{mstate}
 stat	{mstate}
+contactaddress	{mcreatoraddress}
+ciad	{mcreatoraddress}
+contactcity	{mcreatorcity}
+cicy	{mcreatorcity}
+contactstate	{mcreatorstate}
+cist	{mcreatorstate}
+contactzip	{mcreatorzip}
+cizp	{mcreatorzip}
+contactcountry	{mcreatorcountry}
+cicn	{mcreatorcountry}
+contactemail	{mcreatoremail}
+ciem	{mcreatoremail}
+contactphone	{mcreatorphone}
+ciph	{mcreatorphone}
+contactweb	{mcreatorwebsite}
+ciwb	{mcreatorwebsite}
+captionwriter	{mdescwriter}
+cwrt	{mdescwriter}
+instructions	{minstructions}
+inst	{minstructions}
+title	{mcreatorjob}
+titl	{mcreatorjob}
+transref	{mjobidentifier}
+tref	{mjobidentifier}
+usage	{musageterms}
+usag	{musageterms}
+photog	{mcreator}
+phtg	{mcreator}
+copyright	{mcopyright}
+copy	{mcopyright}
+source	{msource}
+srce	{msource}
 
-// TIme & Date
+// TIme & Date	
 ampm	{tampm}
 date	{tdate}
 shot	{tdate}
@@ -74,6 +107,10 @@ mnap	{tmonthps}
 second	{tsecond}
 sec	{tsecond}
 time	{ttime}
-
-// Special Variables
+// Special Variables	
 nl	\n
+	
+	
+	
+	
+	

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -11,7 +11,9 @@
 // start and end strings must be the same size
 var TS_START_DELIM;
 var TS_END_DELIM;
-var TS_DELIM_SIZE; 
+var TS_DELIM_SIZE;
+var TS_DELIM_ENUM = "#";
+var TS_DELIM_FUNC = "|";
 const TS_DELIMITERS = [
 	// starting delim, ending delim, delim length.
 	["[",  "]",  1],
@@ -21,10 +23,11 @@ const TS_DELIMITERS = [
 	["=",  "=",  1],
 	["==", "==", 2],
 ]
-const TS_VERSION = "1.0.1";
-const TS_VERSION_PREFS = 100001; // equal to 1.000.01, or 1.0.1
+const TS_VERSION = "1.1.0";
+const TS_VERSION_PREFS = 100100; // equal to 1.001.00, or 1.1.0
 
 var TS_SUB_TABLE_BUILTIN;
+var TS_SUB_TABLE_BUILTIN_FUNCTIONS;
 var TS_SUB_TABLE_USER;
 
 var TS_NUM_CUSTOM_FILES_LOADED = 0;
@@ -507,28 +510,73 @@ function tsBuildSubstitutionTables(){
 		{ target: "mlabel",				replacement: tsMLabel						},
 
 		// camera-based substitutions
-		{ target: "cwidth",				replacement: tsCWidth						}, 
-		{ target: "cw",					replacement: tsCWidth						}, 
-		{ target: "cheight",			replacement: tsCHeight						}, 
-		{ target: "ch",					replacement: tsCHeight						}, 
-		{ target: "ccamera",			replacement: tsCCamera						}, 
-		{ target: "ccam",				replacement: tsCCamera						}, 
-		{ target: "cserial",			replacement: tsCSerial						}, 
-		{ target: "clens",				replacement: tsCLens						}, 
-		{ target: "cshutterspeed",		replacement: tsCShutterSpeed				}, 
-		{ target: "cshutter",			replacement: tsCShutterSpeed				}, 
-		{ target: "css",				replacement: tsCShutterSpeed				}, 
-		{ target: "caperture",			replacement: tsCAperture					}, 
-		{ target: "cf",					replacement: tsCAperture					}, 
-		{ target: "ciso",				replacement: tsCISO							}, 
-		{ target: "cfocallength",		replacement: tsCFocalLength					}, 
-		{ target: "czoom",				replacement: tsCFocalLength					}, 
-		{ target: "cfocallength35",		replacement: tsCFocalLength35				}, 
-		{ target: "czoom35",			replacement: tsCFocalLength35				}, 
-		{ target: "cexposurecomp",		replacement: tsCExposureComp				}, 
-		{ target: "cexpcomp",			replacement: tsCExposureComp				}, 
+		{ target: "cwidth",				replacement: tsCWidth						},
+		{ target: "cw",					replacement: tsCWidth						},
+		{ target: "cheight",			replacement: tsCHeight						},
+		{ target: "ch",					replacement: tsCHeight						},
+		{ target: "ccamera",			replacement: tsCCamera						},
+		{ target: "ccam",				replacement: tsCCamera						},
+		{ target: "cserial",			replacement: tsCSerial						},
+		{ target: "clens",				replacement: tsCLens						},
+		{ target: "cshutterspeed",		replacement: tsCShutterSpeed				},
+		{ target: "cshutter",			replacement: tsCShutterSpeed				},
+		{ target: "css",				replacement: tsCShutterSpeed				},
+		{ target: "caperture",			replacement: tsCAperture					},
+		{ target: "cf",					replacement: tsCAperture					},
+		{ target: "ciso",				replacement: tsCISO							},
+		{ target: "cfocallength",		replacement: tsCFocalLength					},
+		{ target: "czoom",				replacement: tsCFocalLength					},
+		{ target: "cfocallength35",		replacement: tsCFocalLength35				},
+		{ target: "czoom35",			replacement: tsCFocalLength35				},
+		{ target: "cexposurecomp",		replacement: tsCExposureComp				},
+		{ target: "cexpcomp",			replacement: tsCExposureComp				},
 		{ target: "ccomp",				replacement: tsCExposureComp				}
 
+	]
+
+	const builtinFunctionsTableSize = 53; // size we want for the hashtable - should be a prime at least 2x the size of the associated table.
+	const builtinFunctions = [	// map of built-in functions
+		// math ops
+		{ target: "fadd",				replacement: tsFAdd							},
+		{ target: "f+",					replacement: tsFAdd							},
+		{ target: "fsub",				replacement: tsFSub							},
+		{ target: "f-",					replacement: tsFSub							},
+		{ target: "fmul",				replacement: tsFMul							},
+		{ target: "f*",					replacement: tsFMul							},
+		{ target: "fdiv",				replacement: tsFDiv							},
+		{ target: "f/",					replacement: tsFDiv							},
+		{ target: "fmod",				replacement: tsFMod							},
+		{ target: "f%",					replacement: tsFMod							},
+		{ target: "ffloor",				replacement: tsFFloor						},
+		{ target: "fceil",				replacement: tsFCeil						},
+		{ target: "fround",				replacement: tsFRound						},
+
+		// string ops
+		{ target: "fprefix",			replacement: tsFPrefix						},
+		{ target: "fsuffix",			replacement: tsFSuffix						},
+		
+		// logic
+		{ target: "fequals",			replacement: tsFEquals						},
+		{ target: "feq",				replacement: tsFEquals						},
+		{ target: "f=",					replacement: tsFEquals						},
+		{ target: "fnotequals",			replacement: tsFNotEquals					},
+		{ target: "fneq",				replacement: tsFNotEquals					},
+		{ target: "f!=",				replacement: tsFNotEquals					},
+		{ target: "for",				replacement: tsFOr							},
+		{ target: "f||",				replacement: tsFOr							},
+		{ target: "fand",				replacement: tsFAnd							},
+		{ target: "f&&",				replacement: tsFAnd							},
+		{ target: "fnot",				replacement: tsFNot							},
+		{ target: "f!",					replacement: tsFNot							},
+		
+		// conditionals
+		{ target: "fcondcontinue",		replacement: tsFConditionalContinue			},
+		{ target: "fcc",				replacement: tsFConditionalContinue			},
+		{ target: "fbeq",				replacement: tsFConditionalContinue			},
+		{ target: "fsubstexists",		replacement: tsFSubstitutionExists			},
+		{ target: "fsubexists",			replacement: tsFSubstitutionExists			},
+		{ target: "fsex",				replacement: tsFSubstitutionExists			},
+		
 	]
 
 
@@ -536,6 +584,12 @@ function tsBuildSubstitutionTables(){
 	TS_SUB_TABLE_BUILTIN = new SubstitutionTable(builtinTableSize);
 	for(var i in builtinCommands){
 		TS_SUB_TABLE_BUILTIN.insert(builtinCommands[i]);
+	}
+
+	// build builtin function table
+	TS_SUB_TABLE_BUILTIN_FUNCTIONS = new SubstitutionTable(builtinFunctionsTableSize);
+	for(var i in builtinFunctions){
+		TS_SUB_TABLE_BUILTIN_FUNCTIONS.insert(builtinFunctions[i]);
 	}
 
 	tsBuildCustomSubTables();
@@ -574,9 +628,9 @@ function tsBuildCustomSubTables(){
 	var size;
 	var i = 0;
 	
-	// in the ungodly case someone has > 50,000 substitutions, just pick something that's maybe a prime number
+	// in the ungodly case someone has > 96,000 substitutions, just pick something that's maybe a prime number
 	if(customSubs.length*2 > primes[primes.length-1]){
-		alert("Text Substitutions is impressed!\nIf you're seeing this, you have more than 48,000 substitutions which is way more than I ever expected anyone would use. Don't worry, I added a fallback to ensure the program still works, it will just be slightly less efficent.\n\nAlso, please leave a github issue or email me (9yz [at] 9yz.dev) so I can learn what the fuck you're doing that requires 48,000+ substitutions.");
+		alert("Text Substitutions is impressed!\nIf you're seeing this, you have more than 96,000 substitutions which is way more than I ever expected anyone would use. Don't worry, I added a fallback to ensure the program still works, it will just be slightly less efficent.\n\nAlso, please leave a github issue or email me (9yz [at] 9yz.dev) so I can learn what the fuck you're doing that requires 96,000+ substitutions.");
 		size = (customSubs.length*2)+1; 
 	}
 	else{
@@ -852,15 +906,24 @@ function tsFindReplacement(selection, targetString){
 	TS_RECURSIONS++;
 	checkRecursions(selection); // case: infinite recursion
 
+	// lookup target in builtin function table
+	var splitString = targetString.split(TS_DELIM_FUNC); // [0] will be the function name, [1+] will be args
+	if(splitString.length > 1){
+		replObject = TS_SUB_TABLE_BUILTIN_FUNCTIONS.lookup(splitString[0].toLowerCase());
+		if(replObject != undefined){ // if this is undefined, nothing was found
+			return replObject.replacement(selection, splitString).toString(); // call function, pass splitstring containing args
+		}
+	}
+
 	// lookup target in builtin table
 	var replObject = TS_SUB_TABLE_BUILTIN.lookup(targetString.toLowerCase()); 
 	if(replObject != undefined){ // if this is undefined, nothing was found
 		return replObject.replacement(selection).toString();
 	}
-
 	
+
 	// lookup target in custom table - more complicated bc of enumerated replacements
-	var splitString = targetString.split("#"); // for enumerated substitutions - [0] will be the tag, [1] will be the index. if length=1, enumeration is not being used. 
+	splitString = targetString.split(TS_DELIM_ENUM); // for enumerated substitutions - [0] will be the tag, [1] will be the index. if length=1, enumeration is not being used. 
 	if(splitString.length > 1){
 		splitString[1] = parseInt(splitString[1]); // convert to int	
 	}
@@ -1230,6 +1293,182 @@ function tsCExposureComp(sel){
 
 
 
+///////////////////////
+// MATH FUNCTIONS
+
+// sums all passed values
+function tsFAdd(sel, argv){
+	var result = parseFloat(argv[1]);
+	if(isNaN(result)) result = 0; 
+
+	for(var i = 2; i < argv.length; i++){
+		argv[i] = parseFloat(argv[i]);
+		if(isNaN(argv[i])) argv[i] = 0; // if this was text or something, just treat it as 0.
+		result += argv[i];
+	}
+
+	return result;
+}
+
+// subtracts all passed values
+function tsFSub(sel, argv){
+	var result = parseFloat(argv[1]);
+	if(isNaN(result)) result = 0; 
+
+	for(var i = 2; i < argv.length; i++){
+		argv[i] = parseFloat(argv[i]);
+		if(isNaN(argv[i])) argv[i] = 0; // if this was text or something, just treat it as 0.
+		result -= argv[i];
+	}
+
+	return result;
+}
+
+// multiplies all passed values
+function tsFMul(sel, argv){
+	var result = parseFloat(argv[1]);
+	if(isNaN(result)) result = 1; 
+
+	for(var i = 2; i < argv.length; i++){
+		argv[i] = parseFloat(argv[i]);
+		if(isNaN(argv[i])) argv[i] = 1; // if this was text or something, just treat it as 1.
+		result *= argv[i];
+	}
+
+	return result;
+}
+
+// divides all passed values ; if any args = 0, returns 0
+function tsFDiv(sel, argv){
+	var result = parseFloat(argv[1]);
+	if(isNaN(result)) result = 1; 
+
+	for(var i = 2; i < argv.length; i++){
+		argv[i] = parseFloat(argv[i]);
+		if(isNaN(argv[i])) argv[i] = 1; // if this was text or something, just treat it as 1.
+		if(argv[i] == 0) return 0; // check div/0
+		result /= argv[i];
+	}
+
+	return result;
+}
+
+// takes 2 params, returns the modulo of the first by the second
+function tsFMod(sel, argv){
+	if(argv.length == 2) return argv[1];
+	if(argv.length == 1) return "";
+	var a = parseFloat(argv[1]);
+	if(isNaN(a)) a = 1; 
+	var b = parseFloat(argv[2]);
+	if(isNaN(b)) b = 1; 
+
+	return a%b;
+}
+
+
+function tsFCeil(sel, argv){
+	if(argv.length == 1) return "";
+	return Math.ceil(argv[1]);
+}
+
+function tsFFloor(sel, argv){
+	if(argv.length == 1) return "";
+	return Math.floor(argv[1]);
+}
+
+function tsFRound(sel, argv){
+	if(argv.length == 1) return "";
+	return Math.round(argv[1]);
+}
+
+
+//////////////////////
+// STRING OPERATIONS
+
+
+// returns the first argv[2] characters of argv[1]
+function tsFPrefix(sel, argv){
+	if(argv.length == 2) return argv[1];
+	if(argv.length == 1) return "";
+	argv[2] = parseFloat(argv[2]);
+	if(isNaN(argv[2])) return "";
+	return argv[1].substring(0, argv[2]);
+}
+
+// returns the last argv[2] characters of argv[1]
+function tsFSuffix(sel, argv){
+	if(argv.length == 2) return argv[1];
+	if(argv.length == 1) return "";
+	argv[2] = parseFloat(argv[2]);
+	if(isNaN(argv[2])) return "";
+	return argv[1].substring(argv[1].length-argv[2]);
+}
+
+
+
+//////////////////////
+// CONDITIONALS
+
+
+// returns "1" if all argv[1+] are equal, "0" otherwise
+function tsFEquals(sel, argv){
+	if(argv.length <= 2) return "1";
+
+	for(var i = 2; i < argv.length; i++){
+		if(argv[1] !== argv[i]) return "0";
+	}
+
+	return "1";
+}
+
+// returns "1" if any argv[1+] are different, "0" otherwise
+function tsFNotEquals(sel, argv){
+	return tsFEquals(sel, argv) == "1" ? "0" : "1";
+}
+
+// returns "1" if any argv[1+] == "1", "0" otherwise
+function tsFOr(sel, argv){
+	for(var i = 1; i < argv.length; i++){
+		if(anyToBool(argv[i])) return "1";
+	}
+
+	return "0";
+}
+
+// returns "1" if any argv[1+] == "0" or "", "1" otherwise
+function tsFAnd(sel, argv){
+	for(var i = 1; i < argv.length; i++){
+		if(!anyToBool(argv[i])) return "0";
+	}
+
+	return "1";
+}
+
+// returns "1" if argv[1] == "0" or "", "0" otherwise
+function tsFNot(sel, argv){
+	if(argv.length == 1) return "1";
+	return anyToBool(argv[1]) ? "0" : "1";
+}
+
+
+// returns argv[2] if argv[1] is true, "" otherwise
+function tsFConditionalContinue(sel, argv){
+	if(argv.length < 3) return "";
+	return anyToBool(argv[1]) ? argv[2] : "";
+}
+
+// returns "1" if argv[1] is a valid subst, "0" otherwise
+function tsFSubstitutionExists(sel, argv){
+	if(argv.length == 1) return "";
+	if(TS_SUB_TABLE_USER.lookup(argv[1].toString()) !== undefined) return "1";
+	if(TS_SUB_TABLE_BUILTIN.lookup(argv[1].toString()) !== undefined) return "1";
+	if(TS_SUB_TABLE_BUILTIN_FUNCTIONS.lookup(argv[1].toString()) !== undefined) return "1";
+
+	return "0";
+}
+
+
+
 
 //////////////////////
 // UTILITY FUNCTIONS
@@ -1244,6 +1483,12 @@ function isArray(a){
 	return (a instanceof Array);
 }
 
+// returns false if s = "" or "0", true otherwise
+function anyToBool(s){
+	if(s.length = 0 || s == "0" || s == 0 || s == false) return false;
+	return true;
+}
+ 
 
 
 
@@ -1258,7 +1503,7 @@ function isArray(a){
 
 // size should be a prime at least 2x the number of expected elements
 function SubstitutionTable(size){
-	const b = 37; // "choose b as the first prime number greater or equal to the number of characters in the input alphabet." assuming 26+10 chars in alphabet here
+	const b = 67; // "choose b as the first prime number greater or equal to the number of characters in the input alphabet." assuming 26*2+10 chars in alphabet here
 	var tableSize = 0;
 	var tableLoad = 0; // number of objects in table
 	var table;

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -534,7 +534,7 @@ function tsBuildSubstitutionTables(){
 
 	]
 
-	const builtinFunctionsTableSize = 53; // size we want for the hashtable - should be a prime at least 2x the size of the associated table.
+	const builtinFunctionsTableSize = 101; // size we want for the hashtable - should be a prime at least 2x the size of the associated table.
 	const builtinFunctions = [	// map of built-in functions
 		// math ops
 		{ target: "fadd",				replacement: tsFAdd							},
@@ -562,6 +562,20 @@ function tsBuildSubstitutionTables(){
 		{ target: "fnotequals",			replacement: tsFNotEquals					},
 		{ target: "fneq",				replacement: tsFNotEquals					},
 		{ target: "f!=",				replacement: tsFNotEquals					},
+		{ target: "fgreaterthan",		replacement: tsFGreaterThan					},
+		{ target: "fgt",				replacement: tsFGreaterThan					},
+		{ target: "f>",					replacement: tsFGreaterThan					},
+		{ target: "flessthan",			replacement: tsFLessThan					},
+		{ target: "flt",				replacement: tsFLessThan					},
+		{ target: "f<",					replacement: tsFLessThan					},
+		{ target: "fgreaterequal",		replacement: tsFGreaterEqual				},
+		{ target: "fgeq",				replacement: tsFGreaterEqual				},
+		{ target: "f>=",				replacement: tsFGreaterEqual				},
+		{ target: "f=>",				replacement: tsFGreaterEqual				},
+		{ target: "flessequal",			replacement: tsFLessEqual					},
+		{ target: "fleq",				replacement: tsFLessEqual					},
+		{ target: "f<=",				replacement: tsFLessEqual					},
+		{ target: "f=<",				replacement: tsFLessEqual					},
 		{ target: "for",				replacement: tsFOr							},
 		{ target: "f||",				replacement: tsFOr							},
 		{ target: "fand",				replacement: tsFAnd							},
@@ -628,9 +642,9 @@ function tsBuildCustomSubTables(){
 	var size;
 	var i = 0;
 	
-	// in the ungodly case someone has > 96,000 substitutions, just pick something that's maybe a prime number
+	// in the ungodly case someone has > 48,000 substitutions, just pick something that's maybe a prime number
 	if(customSubs.length*2 > primes[primes.length-1]){
-		alert("Text Substitutions is impressed!\nIf you're seeing this, you have more than 96,000 substitutions which is way more than I ever expected anyone would use. Don't worry, I added a fallback to ensure the program still works, it will just be slightly less efficent.\n\nAlso, please leave a github issue or email me (9yz [at] 9yz.dev) so I can learn what the fuck you're doing that requires 96,000+ substitutions.");
+		alert("Text Substitutions is impressed!\nIf you're seeing this, you have more than 48,000 substitutions which is way more than I ever expected anyone would use. Don't worry, I added a fallback to ensure the program still works, it will just be slightly less efficent.\n\nAlso, please leave a github issue or email me (9yz [at] 9yz.dev) so I can learn what the fuck you're doing that requires 48,000+ substitutions.");
 		size = (customSubs.length*2)+1; 
 	}
 	else{
@@ -1466,6 +1480,52 @@ function tsFSubstitutionExists(sel, argv){
 
 	return "0";
 }
+
+
+// returns "1" if all argv[n>1] > argv[(n>1)+1], "0" otherwise
+function tsFGreaterThan(sel, argv){
+	if(argv.length <= 2) return "1";
+
+	for(var i = 2; i < argv.length; i++){
+		if(argv[i-1] <= argv[i]) return "0";
+	}
+
+	return "1";
+}
+
+// returns "1" if all argv[n>1] < argv[(n>1)+1], "0" otherwise
+function tsFLessThan(sel, argv){
+	if(argv.length <= 2) return "1";
+
+	for(var i = 2; i < argv.length; i++){
+		if(argv[i-1] >= argv[i]) return "0";
+	}
+
+	return "1";
+}
+
+// returns "1" if all argv[n>1] >= argv[(n>1)+1], "0" otherwise
+function tsFGreaterEqual(sel, argv){
+	if(argv.length <= 2) return "1";
+
+	for(var i = 2; i < argv.length; i++){
+		if(argv[i-1] < argv[i]) return "0";
+	}
+
+	return "1";
+}
+
+// returns "1" if all argv[n>1] <= argv[(n>1)+1], "0" otherwise
+function tsFLessEqual(sel, argv){
+	if(argv.length <= 2) return "1";
+
+	for(var i = 2; i < argv.length; i++){
+		if(argv[i-1] > argv[i]) return "0";
+	}
+
+	return "1";
+}
+
 
 
 

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -668,7 +668,9 @@ function tsBuildSubstitutionTables(){
 
 		// string ops
 		{ target: "fprefix",			replacement: tsFPrefix						},
+		{ target: "fpfx",				replacement: tsFPrefix						},
 		{ target: "fsuffix",			replacement: tsFSuffix						},
+		{ target: "fsfx",				replacement: tsFSuffix						},
 		{ target: "fsubstring",			replacement: tsFSubstring					},
 		{ target: "fsubstr",			replacement: tsFSubstring					},
 		

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -43,7 +43,8 @@ var TS_LAST_OP_FILES = 0; // number of files processed in the last operation
 const TS_PROPERTY_CATEGORIES = {
 	core:		1,
 	credit: 	2,
-	misc: 		4
+	misc: 		4,
+	filename:	8,
 };
 
 var TS_USER_PROP_CATS_SELECTON
@@ -100,7 +101,7 @@ function tsPrefsPanel(){
 
 			/*
 			Code for Import https://scriptui.joonas.me — (Triple click to select): 
-			{"activeId":29,"items":{"item-0":{"id":0,"type":"Dialog","parentId":false,"style":{"enabled":true,"varName":"tsPrefsPanelObject","windowType":"Window","creationProps":{"su1PanelCoordinates":true,"maximizeButton":false,"minimizeButton":false,"independent":false,"closeButton":true,"borderless":false,"resizeable":false},"text":"Dialog","preferredSize":[400,0],"margins":16,"orientation":"column","spacing":10,"alignChildren":["left","top"]}},"item-1":{"id":1,"type":"Panel","parentId":7,"style":{"enabled":true,"varName":"panelDelimiter","creationProps":{"borderStyle":"black","su1PanelCoordinates":false},"text":"Code Delimiter","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["fill","top"],"alignment":null}},"item-2":{"id":2,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbSingleBrackets","text":"[Single Brackets]","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":true}},"item-3":{"id":3,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbDoubleBrackets","text":"[[Double Brackets]] ","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":false}},"item-4":{"id":4,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbSingleCurly","text":"{Curly Brackets}","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":false}},"item-5":{"id":5,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbDoubleCurly","text":"{{Double Curlies}}","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":false}},"item-6":{"id":6,"type":"Panel","parentId":7,"style":{"enabled":true,"varName":"panelDateField","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Get Creation Date From","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["fill","top"],"alignment":null}},"item-7":{"id":7,"type":"Group","parentId":17,"style":{"enabled":true,"varName":null,"preferredSize":[0,0],"margins":0,"orientation":"column","spacing":10,"alignChildren":["fill","top"],"alignment":null}},"item-8":{"id":8,"type":"RadioButton","parentId":6,"style":{"enabled":true,"varName":"rbUseEXIFDate","text":"EXIF (reccomended)","preferredSize":[0,0],"alignment":null,"helpTip":"Get date from EXIF. This field is updated by Bridge's \"Edit Capture Time\" feature."}},"item-9":{"id":9,"type":"RadioButton","parentId":6,"style":{"enabled":true,"varName":"rbUseIPTCDate","text":"IPTC","preferredSize":[0,0],"alignment":null,"helpTip":"Get date from IPTC. This field is NOT updated by Bridge's \"Edit Capture Time\" feature."}},"item-10":{"id":10,"type":"StaticText","parentId":6,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"Select which field time-based substitutions like tDate and tTime should get the Creation Date from. ","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-11":{"id":11,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbSingleEquals","text":"=Single Equals=","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-12":{"id":12,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbDoubleEquals","text":"==Double Equals==","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-13":{"id":13,"type":"StaticText","parentId":6,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"tEXIFTime and tIPTCTime will always get the ISO 8601 timestamp from their respective fields.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-14":{"id":14,"type":"Divider","parentId":0,"style":{"enabled":true,"varName":null}},"item-15":{"id":15,"type":"StaticText","parentId":0,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"View documentation and contribute to Text Substitutions at https://github.com/9yz/bridge-scripts","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-16":{"id":16,"type":"StaticText","parentId":1,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"Set the delimiter used to identify substitutions. Don't forget to update  any custom recursive substitutions when changing this setting!","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-17":{"id":17,"type":"Group","parentId":0,"style":{"enabled":true,"varName":null,"preferredSize":[0,0],"margins":0,"orientation":"row","spacing":10,"alignChildren":["left","center"],"alignment":null}},"item-18":{"id":18,"type":"Panel","parentId":19,"style":{"enabled":true,"varName":"panelSepTags","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Separate Substitutions in Keywords","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["fill","top"],"alignment":null}},"item-19":{"id":19,"type":"Group","parentId":17,"style":{"enabled":true,"varName":null,"preferredSize":[0,0],"margins":0,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":null}},"item-20":{"id":20,"type":"StaticText","parentId":18,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"When set, substitutions used in the Keywords field containing commas will be split into multiple keywords.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-21":{"id":21,"type":"StaticText","parentId":18,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"For example, if the substitution [[foods]] is set  to be substituted with \"apples,  crackers\" and this setting is enabled, 2 tags will be created - one  each for \"apples\" and \"crackers\". Otherwise, only one tag will be created","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-22":{"id":22,"type":"Checkbox","parentId":18,"style":{"enabled":true,"varName":"rbSepTags","text":"Separate Substitutions in Keywords","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-23":{"id":23,"type":"Panel","parentId":19,"style":{"enabled":true,"varName":"panelCustomSubs","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Custom Substitutions","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":"fill"}},"item-24":{"id":24,"type":"StaticText","parentId":23,"style":{"enabled":true,"varName":"txtFilesLoaded","creationProps":{},"softWrap":false,"text":"x custom substitution files loaded.\nx custom substitution rules loaded.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-25":{"id":25,"type":"Button","parentId":23,"style":{"enabled":true,"varName":"butReloadCustSubs","text":"Reload Custom Substitutions","justify":"center","preferredSize":[0,0],"alignment":null,"helpTip":"This will purge all custom substitutions from memory and reload them from disk."}},"item-26":{"id":26,"type":"StaticText","parentId":23,"style":{"enabled":true,"varName":null,"creationProps":{"truncate":"none","multiline":false,"scrolling":false},"softWrap":false,"text":"All .txt files beginning with \"ts_\" in the Startup Scripts directory or  /substitutions/ subdirectory will be loaded.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-27":{"id":27,"type":"Panel","parentId":19,"style":{"enabled":true,"varName":"panelMaxRecursions","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Max Substitutions","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":"fill"}},"item-28":{"id":28,"type":"StaticText","parentId":27,"style":{"enabled":true,"varName":null,"creationProps":{"truncate":"none","multiline":false,"scrolling":false},"softWrap":false,"text":"Maximum number of substitutions in a single metadata field before an error occurs. Lower numbers could cause problems when many recursive substitutions are used. ","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-29":{"id":29,"type":"EditText","parentId":27,"style":{"enabled":true,"varName":"edMaxRecursions","creationProps":{"noecho":false,"readonly":false,"multiline":false,"scrollable":false,"borderless":true,"enterKeySignalsOnChange":false},"softWrap":false,"text":"100","justify":"left","preferredSize":[40,0],"alignment":null,"helpTip":null}}},"order":[0,17,7,1,16,2,3,4,5,11,12,6,10,13,8,9,19,18,20,21,22,23,26,25,24,27,28,29,14,15],"settings":{"importJSON":true,"indentSize":false,"cepExport":false,"includeCSSJS":true,"showDialog":true,"functionWrapper":false,"afterEffectsDockable":false,"itemReferenceList":"None"}}
+			{"activeId":38,"items":{"item-0":{"id":0,"type":"Dialog","parentId":false,"style":{"enabled":true,"varName":"tsPrefsPanelObject","windowType":"Window","creationProps":{"su1PanelCoordinates":true,"maximizeButton":false,"minimizeButton":false,"independent":false,"closeButton":true,"borderless":false,"resizeable":false},"text":"Dialog","preferredSize":[400,0],"margins":16,"orientation":"column","spacing":10,"alignChildren":["left","top"]}},"item-1":{"id":1,"type":"Panel","parentId":7,"style":{"enabled":true,"varName":"panelDelimiter","creationProps":{"borderStyle":"black","su1PanelCoordinates":false},"text":"Code Delimiter","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["fill","top"],"alignment":null}},"item-2":{"id":2,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbSingleBrackets","text":"[Single Brackets]","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":true}},"item-3":{"id":3,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbDoubleBrackets","text":"[[Double Brackets]] ","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":false}},"item-4":{"id":4,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbSingleCurly","text":"{Curly Brackets}","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":false}},"item-5":{"id":5,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbDoubleCurly","text":"{{Double Curlies}}","preferredSize":[0,0],"alignment":null,"helpTip":null,"checked":false}},"item-6":{"id":6,"type":"Panel","parentId":7,"style":{"enabled":true,"varName":"panelDateField","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Get Creation Date From","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["fill","top"],"alignment":null}},"item-7":{"id":7,"type":"Group","parentId":17,"style":{"enabled":true,"varName":null,"preferredSize":[0,0],"margins":0,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":null}},"item-8":{"id":8,"type":"RadioButton","parentId":6,"style":{"enabled":true,"varName":"rbUseEXIFDate","text":"EXIF (reccomended)","preferredSize":[0,0],"alignment":null,"helpTip":"Get date from EXIF. This field is updated by Bridge's \"Edit Capture Time\" feature."}},"item-9":{"id":9,"type":"RadioButton","parentId":6,"style":{"enabled":true,"varName":"rbUseIPTCDate","text":"IPTC","preferredSize":[0,0],"alignment":null,"helpTip":"Get date from IPTC. This field is NOT updated by Bridge's \"Edit Capture Time\" feature."}},"item-10":{"id":10,"type":"StaticText","parentId":6,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"Select which field time-based substitutions like tDate and tTime should get the Creation Date from. ","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-11":{"id":11,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbSingleEquals","text":"=Single Equals=","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-12":{"id":12,"type":"RadioButton","parentId":1,"style":{"enabled":true,"varName":"rbDoubleEquals","text":"==Double Equals==","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-13":{"id":13,"type":"StaticText","parentId":6,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"tEXIFTime and tIPTCTime will always get the ISO 8601 timestamp from their respective fields.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-14":{"id":14,"type":"Divider","parentId":0,"style":{"enabled":true,"varName":null}},"item-15":{"id":15,"type":"StaticText","parentId":0,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"View documentation and contribute to Text Substitutions at https://github.com/9yz/bridge-scripts","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-16":{"id":16,"type":"StaticText","parentId":1,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"Set the delimiter used to identify substitutions. Don't forget to update  any custom recursive substitutions when changing this setting!","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-17":{"id":17,"type":"Group","parentId":0,"style":{"enabled":true,"varName":null,"preferredSize":[0,0],"margins":0,"orientation":"row","spacing":10,"alignChildren":["left","center"],"alignment":null}},"item-18":{"id":18,"type":"Panel","parentId":19,"style":{"enabled":true,"varName":"panelSepTags","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Separate Substitutions in Keywords","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["fill","top"],"alignment":null}},"item-19":{"id":19,"type":"Group","parentId":17,"style":{"enabled":true,"varName":null,"preferredSize":[0,0],"margins":0,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":null}},"item-20":{"id":20,"type":"StaticText","parentId":18,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"When set, substitutions used in the Keywords field containing commas will be split into multiple keywords.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-21":{"id":21,"type":"StaticText","parentId":18,"style":{"enabled":true,"varName":null,"creationProps":{},"softWrap":true,"text":"For example, if the substitution [[foods]] is set  to be substituted with \"apples,  crackers\" and this setting is enabled, 2 tags will be created - one  each for \"apples\" and \"crackers\". Otherwise, only one tag will be created","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-22":{"id":22,"type":"Checkbox","parentId":18,"style":{"enabled":true,"varName":"rbSepTags","text":"Separate Substitutions in Keywords","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-23":{"id":23,"type":"Panel","parentId":19,"style":{"enabled":true,"varName":"panelCustomSubs","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Custom Substitutions","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":"fill"}},"item-24":{"id":24,"type":"StaticText","parentId":23,"style":{"enabled":true,"varName":"txtFilesLoaded","creationProps":{},"softWrap":false,"text":"x custom substitution files loaded.\nx custom substitution rules loaded.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-25":{"id":25,"type":"Button","parentId":23,"style":{"enabled":true,"varName":"butReloadCustSubs","text":"Reload Custom Substitutions","justify":"center","preferredSize":[0,0],"alignment":null,"helpTip":"This will purge all custom substitutions from memory and reload them from disk."}},"item-26":{"id":26,"type":"StaticText","parentId":23,"style":{"enabled":true,"varName":null,"creationProps":{"truncate":"none","multiline":false,"scrolling":false},"softWrap":false,"text":"All .txt files beginning with \"ts_\" in the Startup Scripts directory or  /substitutions/ subdirectory will be loaded.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-27":{"id":27,"type":"Panel","parentId":19,"style":{"enabled":true,"varName":"panelMaxRecursions","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Max Substitutions","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":"fill"}},"item-28":{"id":28,"type":"StaticText","parentId":27,"style":{"enabled":true,"varName":null,"creationProps":{"truncate":"none","multiline":false,"scrolling":false},"softWrap":false,"text":"Maximum number of substitutions in a single metadata field before an error occurs. Lower numbers could cause problems when many recursive substitutions are used. ","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-29":{"id":29,"type":"EditText","parentId":27,"style":{"enabled":true,"varName":"edMaxRecursions","creationProps":{"noecho":false,"readonly":false,"multiline":false,"scrollable":false,"borderless":true,"enterKeySignalsOnChange":false},"softWrap":false,"text":"100","justify":"left","preferredSize":[40,0],"alignment":null,"helpTip":null}},"item-30":{"id":30,"type":"Panel","parentId":31,"style":{"enabled":true,"varName":"panelPropertyCategories","creationProps":{"borderStyle":"etched","su1PanelCoordinates":false},"text":"Fields to Analyze","preferredSize":[0,0],"margins":10,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":null}},"item-31":{"id":31,"type":"Group","parentId":17,"style":{"enabled":true,"varName":null,"preferredSize":[0,0],"margins":0,"orientation":"column","spacing":10,"alignChildren":["left","top"],"alignment":null}},"item-32":{"id":32,"type":"StaticText","parentId":30,"style":{"enabled":true,"varName":null,"creationProps":{"truncate":"none","multiline":false,"scrolling":false},"softWrap":false,"text":"Only these fields will be checked for custom substitutions when the program is run. Reducing the number of fields analyzed will improve performance. Only fields in IPTC Core (not IPTC Extension) are analyzed.","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-34":{"id":34,"type":"Checkbox","parentId":30,"style":{"enabled":true,"varName":"cbPropCatCore","text":"Core","preferredSize":[0,0],"alignment":null,"helpTip":"Description, keywords, alt-text, extended description,\\nheadline, title, sublocation, city, state, country."}},"item-35":{"id":35,"type":"Checkbox","parentId":30,"style":{"enabled":true,"varName":"cbPropCatCredit","text":"Credit","preferredSize":[0,0],"alignment":null,"helpTip":"Creator contact info, credit, source,\\ndescription writer, rights, and usage terms."}},"item-36":{"id":36,"type":"Checkbox","parentId":30,"style":{"enabled":true,"varName":"cbPropCatMisc","text":"Misc","preferredSize":[0,0],"alignment":null,"helpTip":"IPTC Subject & Scene codes, intellectual genre, \\njob identifier, instructions."}},"item-37":{"id":37,"type":"StaticText","parentId":30,"style":{"enabled":true,"varName":null,"creationProps":{"truncate":"none","multiline":false,"scrolling":false},"softWrap":false,"text":"(hover for details)","justify":"left","preferredSize":[0,0],"alignment":null,"helpTip":null}},"item-38":{"id":38,"type":"Checkbox","parentId":30,"style":{"enabled":true,"varName":"cbPropCatFilename","text":"Filename","preferredSize":[0,0],"alignment":null,"helpTip":"The file's filename. Use caution\\nwhen changing file extensions."}}},"order":[0,17,7,1,16,2,3,4,5,11,12,6,10,13,8,9,19,18,20,21,22,23,26,25,24,27,28,29,31,30,32,38,34,35,36,37,14,15],"settings":{"importJSON":true,"indentSize":false,"cepExport":false,"includeCSSJS":true,"showDialog":true,"functionWrapper":false,"afterEffectsDockable":false,"itemReferenceList":"None"}}
 
 			*/ 
 
@@ -381,6 +382,10 @@ function tsPrefsPanel(){
 			var statictext8 = panelPropertyCategories.add("statictext", undefined, undefined, {name: "statictext8", multiline: true}); 
     		statictext8.text = "Only these fields will be checked for custom substitutions when the program is run. Reducing the number of fields analyzed will improve performance. Only fields in IPTC Core (not IPTC Extension) are analyzed."; 
 
+			var cbPropCatFilename = panelPropertyCategories.add("checkbox", undefined, undefined, {name: "cbPropCatFilename"}); 
+				cbPropCatFilename.helpTip = "The file's filename. Use caution\nwhen changing file extensions."; 
+				cbPropCatFilename.text = "Filename"; 
+
 			var cbPropCatCore = panelPropertyCategories.add("checkbox", undefined, undefined, {name: "cbPropCatCore"}); 
 				cbPropCatCore.helpTip = "Description, keywords, alt-text, extended description,\nheadline, title, sublocation, city, state, country, and country code."; 
 				cbPropCatCore.text = "Core"; 
@@ -394,6 +399,9 @@ function tsPrefsPanel(){
 				cbPropCatMisc.text = "Misc"; 
 
 				// initalize delimiter values
+				if(app.preferences.tsPropertyCategories & TS_PROPERTY_CATEGORIES.filename){
+					cbPropCatFilename.value = true;
+				}
 				if(app.preferences.tsPropertyCategories & TS_PROPERTY_CATEGORIES.core){
 					cbPropCatCore.value = true;
 				}
@@ -405,6 +413,10 @@ function tsPrefsPanel(){
 				}
 
 				// update values on select
+				cbPropCatFilename.onClick = function(){
+					if(cbPropCatFilename.value) app.preferences.tsPropertyCategories |= TS_PROPERTY_CATEGORIES.filename;
+					else app.preferences.tsPropertyCategories ^= TS_PROPERTY_CATEGORIES.filename;
+				}
 				cbPropCatCore.onClick = function(){
 					if(cbPropCatCore.value) app.preferences.tsPropertyCategories |= TS_PROPERTY_CATEGORIES.core;
 					else app.preferences.tsPropertyCategories ^= TS_PROPERTY_CATEGORIES.core;
@@ -579,12 +591,38 @@ function tsBuildSubstitutionTables(){
 		{ target: "mlocation",			replacement: tsMLocation					},
 		{ target: "mcity",				replacement: tsMCity						},
 		{ target: "mstate",				replacement: tsMState						},
+		{ target: "mregion",			replacement: tsMState						},
 		{ target: "mprovince",			replacement: tsMState						},
 		{ target: "mcountry",			replacement: tsMCountry						}, 
 		{ target: "mrating",			replacement: tsMRating						}, 
 		{ target: "mratingpretty",		replacement: tsMRatingPretty				}, 
 		{ target: "mratingp",			replacement: tsMRatingPretty				},
 		{ target: "mlabel",				replacement: tsMLabel						},
+		{ target: "msource",			replacement: tsMSource						},
+		{ target: "mcaptionwriter",		replacement: tsMCaptionWriter				},
+		{ target: "mdescwriter",		replacement: tsMCaptionWriter				},
+		{ target: "mcopyrightnotice",	replacement: tsMCopyrightNotice				},
+		{ target: "mcopyright",			replacement: tsMCopyrightNotice				},
+		{ target: "mrightsusageterms",	replacement: tsMUsageTerms					},
+		{ target: "musageterms",		replacement: tsMUsageTerms					},
+		{ target: "mjobidentifier",		replacement: tsMJobIdentifier				},
+		{ target: "mjobident",			replacement: tsMJobIdentifier				},
+		{ target: "mjob",				replacement: tsMJobIdentifier				},
+		{ target: "minstructions",		replacement: tsMInstructions				},
+		{ target: "mcreator",			replacement: tsMCreator						},
+		{ target: "mcreatorjob",		replacement: tsMCreatorJob					},
+		{ target: "mcreatoraddress",	replacement: tsMCreatorAddress				},
+		{ target: "mcreatorcity",		replacement: tsMCreatorCity					},
+		{ target: "mcreatorregion",		replacement: tsMCreatorState				},
+		{ target: "mcreatorprovince",	replacement: tsMCreatorState				},
+		{ target: "mcreatorstate",		replacement: tsMCreatorState				},
+		{ target: "mcreatorcountry",	replacement: tsMCreatorCountry				},
+		{ target: "mcreatorzip",		replacement: tsMCreatorPostalCode			},
+		{ target: "mcreatorpostal",		replacement: tsMCreatorPostalCode			},
+		{ target: "mcreatorphone",		replacement: tsMCreatorPhone				},
+		{ target: "mcreatoremail",		replacement: tsMCreatorEmail				},
+		{ target: "mcreatorwebsite",	replacement: tsMCreatorWebsite				},
+		
 
 		// camera-based substitutions
 		{ target: "cwidth",				replacement: tsCWidth						},
@@ -803,7 +841,7 @@ function tsRun(){
 		{ type: "simple",	category: TS_PROPERTY_CATEGORIES.credit,	namespace: XMPConst.NS_PHOTOSHOP,	key: "CaptionWriter",			},
 		{ type: "simple",	category: TS_PROPERTY_CATEGORIES.credit,	namespace: XMPConst.NS_DC,			key: "creator",					},
 		{ type: "simple",	category: TS_PROPERTY_CATEGORIES.credit,	namespace: XMPConst.NS_DC,			key: "rights",					},
-		{ type: "simple",	category: TS_PROPERTY_CATEGORIES.credit,	namespace: XMPConst.NS_XMP_RIGHTS,	key: "UsageTerms",				},
+		{ type: "localized",category: TS_PROPERTY_CATEGORIES.credit,	namespace: XMPConst.NS_XMP_RIGHTS,	key: "UsageTerms",				},	// because UsageTerms just wants to be special and refuses to behave like other tags that USE LOCALIZATION but don't FREAK THE FUCK OUT when you dont explicitly insert localized text
 		{ type: "complex",	category: TS_PROPERTY_CATEGORIES.credit,	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 	fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiEmailWork"	},
 		{ type: "complex",	category: TS_PROPERTY_CATEGORIES.credit,	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 	fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiUrlWork"		},
 		{ type: "complex",	category: TS_PROPERTY_CATEGORIES.credit,	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 	fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiAdrExtadr"	},
@@ -891,6 +929,7 @@ function tsRun(){
 
 					for(j in propertyList){
 						if(app.preferences.tsPropertyCategories & propertyList[j].category){ // check if users has enabled this cat
+							// alert("checking param # " + j + ", " + propertyList[j].type != "complex" ? propertyList[j].key : propertyList[j].fieldName);
 							TS_RECURSIONS = 0;
 
 							if(propertyList[j].type == "array"){ // process array fields
@@ -915,7 +954,6 @@ function tsRun(){
 								value = tsDoSubstitutions(selection[i], value); // do substitutions on it
 								myXMP.deleteProperty(propertyList[j].namespace, propertyList[j].key); // delete the existing value
 								myXMP.setProperty(propertyList[j].namespace, propertyList[j].key, value); // replace with new value
-
 							}
 							else if(propertyList[j].type == "complex"){
 								value = myXMP.getStructField(propertyList[j].schemaNS, propertyList[j].structName, propertyList[j].fieldNS, propertyList[j].fieldName); // get existing value
@@ -923,7 +961,21 @@ function tsRun(){
 								myXMP.deleteStructField(propertyList[j].schemaNS, propertyList[j].structName, propertyList[j].fieldNS, propertyList[j].fieldName); // delete the existing value
 								myXMP.setStructField(propertyList[j].schemaNS, propertyList[j].structName, propertyList[j].fieldNS, propertyList[j].fieldName, value); // replace with new value
 							}
+							else if(propertyList[j].type == "localized"){ // because UsageTerms is the product of the devil himself and reading/writing to it refuses to behave like EVERY OTHER FUCKING PROPERTY???
+								if(myXMP.doesPropertyExist(propertyList[j].namespace, propertyList[j].key)){ // fuck you for making me do this
+									value = selection[i].metadata.read(propertyList[j].namespace, propertyList[j].key);
+									value = tsDoSubstitutions(selection[i], value); 
+									myXMP.deleteProperty(propertyList[j].namespace, propertyList[j].key); 
+									myXMP.setLocalizedText(propertyList[j].namespace, propertyList[j].key, "x-default", "x-default", value); // localized properties need to have their language explicitly defined or they refuse to work
+								}
+							}
 						}
+					}
+
+					if(app.preferences.tsPropertyCategories & TS_PROPERTY_CATEGORIES.filename){ // process filename
+						value = selection[i].name;
+						value = tsDoSubstitutions(selection[i], value);
+						selection[i].name = value;
 					}
 					
 				} catch(e){
@@ -943,7 +995,7 @@ function tsRun(){
 		TS_LAST_OP_FILES = selection.length;	
 		
 		if(errorFiles > 0){
-			alert("Text Substitutions Error:\n" + errorFiles + " files were not processed because they do not support metadata.")
+			alert("Text Substitutions Warning:\n" + errorFiles + " files were not processed because they do not support metadata.")
 		}
 		
 		app.synchronousMode = false;
@@ -1340,7 +1392,95 @@ function tsMLabel(sel){
 	return sel.core.quickMetadata.label;
 }
 
+// returns the Source field
+function tsMSource(sel){
+	return sel.metadata.read(XMPConst.NS_PHOTOSHOP, "Source");
+}
 
+// returns the Desc Writer
+function tsMCaptionWriter(sel){
+	return sel.metadata.read(XMPConst.NS_PHOTOSHOP, "CaptionWriter");
+}
+
+// returns the Copyright Notice
+function tsMCopyrightNotice(sel){
+	return sel.metadata.read(XMPConst.NS_DC, "rights");
+}
+
+// returns the Rights Usage Terms
+function tsMUsageTerms(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	if(myXMP.doesPropertyExist(XMPConst.NS_XMP_RIGHTS, "UsageTerms")) return sel.metadata.read(XMPConst.NS_XMP_RIGHTS, "UsageTerms"); // likes to error if you dont check first
+	return "";
+}
+
+// returns the Job Ident
+function tsMJobIdentifier(sel){
+	return sel.metadata.read(XMPConst.NS_PHOTOSHOP, "TransmissionReference");
+}
+
+// returns the Instructions field
+function tsMInstructions(sel){
+	return sel.metadata.read(XMPConst.NS_PHOTOSHOP, "Instructions");
+}
+
+// returns the creator's name
+function tsMCreator(sel){
+	return sel.metadata.read(XMPConst.NS_DC, "creator");
+}
+
+// returns the creator's name
+function tsMCreatorJob(sel){
+	return sel.metadata.read(XMPConst.NS_PHOTOSHOP, "AuthorsPosition");
+}
+
+// returns the creator's email
+function tsMCreatorEmail(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiEmailWork");
+}
+
+// returns the creator's website
+function tsMCreatorWebsite(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiUrlWork");
+}
+
+// returns the creator's address
+function tsMCreatorAddress(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiAdrExtadr");
+}
+
+// returns the creator's city
+function tsMCreatorCity(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiAdrCity");
+}
+
+// returns the creator's state
+function tsMCreatorState(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiAdrRegion");
+}
+
+// returns the creator's zip
+function tsMCreatorPostalCode(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiAdrPcode");
+}
+
+// returns the creator's country
+function tsMCreatorCountry(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiAdrCtry");
+}
+
+// returns the creator's phone
+function tsMCreatorPhone(sel){
+	var myXMP = new XMPMeta(sel.synchronousMetadata.serialize());
+	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiTelWork");
+}
 
 
 //////////////////////////

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -710,16 +710,36 @@ function parseTSV(inputFile, output){
 // Run when the script is selected. Gets user input, selects properties to edit, and passes them to tsDoSubstitutions()
 function tsRun(){
 	const propertyList = [
-		{ namespace: XMPConst.NS_PHOTOSHOP, key: "City", 					isArray: false },
-		{ namespace: XMPConst.NS_PHOTOSHOP, key: "State", 					isArray: false },
-		{ namespace: XMPConst.NS_PHOTOSHOP, key: "Country", 				isArray: false },
-		{ namespace: XMPConst.NS_IPTC_CORE, key: "Location", 				isArray: false },
-		{ namespace: XMPConst.NS_DC,		key: "title", 					isArray: false },
-		{ namespace: XMPConst.NS_PHOTOSHOP, key: "Headline", 				isArray: false },
-		{ namespace: XMPConst.NS_IPTC_CORE, key: "AltTextAccessibility",	isArray: false },
-		{ namespace: XMPConst.NS_IPTC_CORE, key: "ExtDescrAccessibility",	isArray: false },
-		{ namespace: XMPConst.NS_DC,		key: "subject", 				isArray: true }, // keywords
-		{ namespace: XMPConst.NS_DC,		key: "description", 			isArray: false }
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_PHOTOSHOP, 	key: "City", 					},
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_PHOTOSHOP, 	key: "State", 					},
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_PHOTOSHOP, 	key: "Country", 				},
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_IPTC_CORE, 	key: "Location", 				},
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_DC,			key: "title", 					},
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_PHOTOSHOP, 	key: "Headline", 				},
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_IPTC_CORE, 	key: "AltTextAccessibility",	},
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_IPTC_CORE, 	key: "ExtDescrAccessibility",	},
+		{ type: "array",	category: "core",	namespace: XMPConst.NS_DC,			key: "subject", 				}, // keywords
+		{ type: "simple",	category: "core",	namespace: XMPConst.NS_DC,			key: "description", 			},
+		{ type: "simple",	category: "credit",	namespace: XMPConst.NS_PHOTOSHOP,	key: "AuthorsPosition",			},
+		{ type: "simple",	category: "credit",	namespace: XMPConst.NS_PHOTOSHOP,	key: "Credit",					},
+		{ type: "simple",	category: "credit",	namespace: XMPConst.NS_PHOTOSHOP,	key: "Source",					},
+		{ type: "simple",	category: "credit",	namespace: XMPConst.NS_PHOTOSHOP,	key: "CaptionWriter",			},
+		{ type: "simple",	category: "credit",	namespace: XMPConst.NS_DC,			key: "creator",					},
+		{ type: "simple",	category: "credit",	namespace: XMPConst.NS_DC,			key: "rights",					},
+		{ type: "simple",	category: "credit",	namespace: XMPConst.NS_XMP_RIGHTS,	key: "UsageTerms",				},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiEmailWork"	},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiUrlWork"		},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiAdrExtadr"	},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiAdrCity"		},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiAdrRegion"	},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiAdrPcode"		},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiAdrCtry"		},
+		{ type: "complex",	category: "credit",	schemaNS: XMPConst.NS_IPTC_CORE,	structName: "CreatorContactInfo", 		fieldNS: XMPConst.NS_IPTC_CORE, fieldName: "CiTelWork"		},
+		{ type: "simple",	category: "misc",	namespace: XMPConst.NS_IPTC_CORE,	key: "SubjectCode",				},
+		{ type: "simple",	category: "misc",	namespace: XMPConst.NS_IPTC_CORE,	key: "IntellectualGenre",		},
+		{ type: "simple",	category: "misc",	namespace: XMPConst.NS_IPTC_CORE,	key: "Scene",					},
+		{ type: "simple",	category: "misc",	namespace: XMPConst.NS_PHOTOSHOP,	key: "TransmissionReference",	},
+		{ type: "simple",	category: "misc",	namespace: XMPConst.NS_PHOTOSHOP,	key: "Instructions",			},
 	]
 
 	try{
@@ -795,7 +815,7 @@ function tsRun(){
 					for(j in propertyList){
 						TS_RECURSIONS = 0;
 
-						if(propertyList[j].isArray){ // process array fields
+						if(propertyList[j].type = "array"){ // process array fields
 
 							value = selection[i].metadata.read(propertyList[j].namespace, propertyList[j].key).toString(); // grab existing var
 							myXMP.deleteProperty(propertyList[j].namespace, propertyList[j].key); // delete it
@@ -813,12 +833,18 @@ function tsRun(){
 								else myXMP.appendArrayItem(propertyList[j].namespace, propertyList[j].key, value[k], 0, XMPConst.ARRAY_IS_ORDERED);
 							}
 						}
-						else{ // proccess non-array fields
+						else if(propertyList[j].type = "simple"){ // proccess simple fields
 							value = selection[i].metadata.read(propertyList[j].namespace, propertyList[j].key); // get existing value
 							value = tsDoSubstitutions(selection[i], value); // do substitutions on it
 							myXMP.deleteProperty(propertyList[j].namespace, propertyList[j].key); // delete the existing value
 							myXMP.setProperty(propertyList[j].namespace, propertyList[j].key, value); // replace with new value
 
+						}
+						else if(propertyList[j].type = "complex"){
+							value = myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiEmailWork"); // get existing value
+							value = tsDoSubstitutions(selection[i], value); // do substitutions on it
+							myXMP.deleteProperty(propertyList[j].namespace, propertyList[j].key); // delete the existing value
+							myXMP.setProperty(propertyList[j].namespace, propertyList[j].key, value); // replace with new value
 						}
 					}
 					

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -591,6 +591,7 @@ function tsBuildSubstitutionTables(){
 		{ target: "fbeq",				replacement: tsFConditionalContinue			},
 		{ target: "fsubstexists",		replacement: tsFSubstitutionExists			},
 		{ target: "fsubexists",			replacement: tsFSubstitutionExists			},
+		{ target: "fexists",			replacement: tsFSubstitutionExists			},
 		{ target: "fsex",				replacement: tsFSubstitutionExists			},
 		
 	]
@@ -1473,18 +1474,32 @@ function tsFNot(sel, argv){
 }
 
 
-// returns argv[2] if argv[1] is true, "" otherwise
+// returns argv[2] if argv[1] is true. if argv[4] exists, return that. otherwise, return "".
 function tsFConditionalContinue(sel, argv){
 	if(argv.length < 3) return "";
-	return anyToBool(argv[1]) ? argv[2] : "";
+
+	var ret = argv[2];
+	if(anyToBool(argv[1])) return;
+	else if(argv.length = 3) return "";
+	else return argv[4];
 }
 
 // returns "1" if argv[1] is a valid subst, "0" otherwise
 function tsFSubstitutionExists(sel, argv){
 	if(argv.length == 1) return "";
-	if(TS_SUB_TABLE_USER.lookup(argv[1].toString()) !== undefined) return "1";
-	if(TS_SUB_TABLE_BUILTIN.lookup(argv[1].toString()) !== undefined) return "1";
-	if(TS_SUB_TABLE_BUILTIN_FUNCTIONS.lookup(argv[1].toString()) !== undefined) return "1";
+
+	var s = argv[1].toString();
+	var t = s.split(TS_DELIM_ENUM); // case: enumerated replacements
+	var r;
+	if(t.length > 1) r = TS_SUB_TABLE_USER.lookup(t[0]);
+	else r = TS_SUB_TABLE_USER.lookup(s);
+
+	if(r !== undefined){
+		if(t.length == 1 || ( 0 < t[1] && t[1] <= r.replacement.length)) return "1"; // either no enum or enum is in range for this subst
+		return "0";
+	}
+	if(TS_SUB_TABLE_BUILTIN.lookup(s) !== undefined) return "1";
+	if(TS_SUB_TABLE_BUILTIN_FUNCTIONS.lookup(s) !== undefined) return "1";
 
 	return "0";
 }

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -477,7 +477,7 @@ function tsSetDefaultPrefs(allPrefs){
 		app.preferences.tsDelimiter = 1; // int representing the `delimiters` array index of the delimiter to use
 		app.preferences.tsDateField = 0; // 0 = EXIF, 1 = IPTC
 		app.preferences.tsSeparateTags = 0; // 1 = seperate tags
-		app.preferences.tsRecursionLimit = 250; // max number of recursions before error
+		app.preferences.tsRecursionLimit = 500; // max number of recursions before error
 	}
 	app.preferences.tsPrefsVersion = TS_VERSION_PREFS;
 	app.preferences.tsPrefsSet = true;

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -494,6 +494,8 @@ function tsBuildSubstitutionTables(){
 		{ target: "mnames",				replacement: tsMFileNameShort				},
 		{ target: "mfoldername",		replacement: tsMFolderName					},
 		{ target: "mfolder",			replacement: tsMFolderName					},
+		{ target: "mextension",			replacement: tsMExtension					},
+		{ target: "mfiletype",			replacement: tsMExtension					},
 		{ target: "mtitle",				replacement: tsMTitle						},
 		{ target: "mheadline",			replacement: tsMHeadline					},
 		{ target: "mcredit",			replacement: tsMCreditLine					},
@@ -530,7 +532,7 @@ function tsBuildSubstitutionTables(){
 		{ target: "czoom35",			replacement: tsCFocalLength35				},
 		{ target: "cexposurecomp",		replacement: tsCExposureComp				},
 		{ target: "cexpcomp",			replacement: tsCExposureComp				},
-		{ target: "ccomp",				replacement: tsCExposureComp				}
+		{ target: "ccomp",				replacement: tsCExposureComp				},
 
 	]
 
@@ -716,7 +718,7 @@ function tsRun(){
 		{ namespace: XMPConst.NS_IPTC_CORE, key: "AltTextAccessibility",	isArray: false },
 		{ namespace: XMPConst.NS_IPTC_CORE, key: "ExtDescrAccessibility",	isArray: false },
 		{ namespace: XMPConst.NS_DC,		key: "subject", 				isArray: true }, // keywords
-		{ namespace: XMPConst.NS_DC,		key: "description", 			isArray: false },
+		{ namespace: XMPConst.NS_DC,		key: "description", 			isArray: false }
 	]
 
 	try{
@@ -770,7 +772,7 @@ function tsRun(){
 
 		}
 
-		var meow = $.hiresTimer; // dummy var, timer resets on access
+		var meow = $.hiresTimer; // dummy var bc timer resets on access
 		
 		for(var i = 0; i < selection.length; i++){ 
 			if(useDialog){ // update the progress dialog
@@ -792,7 +794,7 @@ function tsRun(){
 					for(j in propertyList){
 						TS_RECURSIONS = 0;
 
-						if(propertyList[j].isArray){
+						if(propertyList[j].isArray){ // process array fields
 
 							value = selection[i].metadata.read(propertyList[j].namespace, propertyList[j].key).toString(); // grab existing var
 							myXMP.deleteProperty(propertyList[j].namespace, propertyList[j].key); // delete it
@@ -810,7 +812,7 @@ function tsRun(){
 								else myXMP.appendArrayItem(propertyList[j].namespace, propertyList[j].key, value[k], 0, XMPConst.ARRAY_IS_ORDERED);
 							}
 						}
-						else{
+						else{ // proccess non-array fields
 							value = selection[i].metadata.read(propertyList[j].namespace, propertyList[j].key); // get existing value
 							value = tsDoSubstitutions(selection[i], value); // do substitutions on it
 							myXMP.deleteProperty(propertyList[j].namespace, propertyList[j].key); // delete the existing value
@@ -1166,6 +1168,12 @@ function tsMFileNameShort(sel){
 // returns the name of the parent folder
 function tsMFolderName(sel){
 	return sel.parent.name;
+}
+
+// returns the file extension
+function tsMExtension(sel){
+	var n = sel.name;
+	return n.substring(n.lastIndexOf('.')+1);
 }
 
 // returns the DC title param

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -531,7 +531,7 @@ function tsInitalizePrefsDelimiter(){
 
 // Build builtin and custom substitution tables
 function tsBuildSubstitutionTables(){
-	const builtinTableSize = 211; // size we want for the hashtable - should be a prime at least 2x the size of builtinCommands.
+	const builtinTableSize = 223; // size we want for the hashtable - should be a prime at least 2x the size of builtinCommands.
 	const builtinCommands = [ // map of all program-defined substitutions
 		// time-based substitutions
 		{ target: "tdate",				replacement: tsTDateTaken					},
@@ -649,7 +649,7 @@ function tsBuildSubstitutionTables(){
 
 	]
 
-	const builtinFunctionsTableSize = 101; // size we want for the hashtable - should be a prime at least 2x the size of the associated table.
+	const builtinFunctionsTableSize = 113; // size we want for the hashtable - should be a prime at least 2x the size of the associated table.
 	const builtinFunctions = [	// map of built-in functions
 		// math ops
 		{ target: "fadd",				replacement: tsFAdd							},

--- a/ts_customSubs.txt
+++ b/ts_customSubs.txt
@@ -11,7 +11,7 @@
 // - Custom substitution files are not checked for correctness when loaded - incorrect formatting may lead to errors when running the script.
 // - Duplicate substitutions (two substitutions with the same target) are not supported. This is not checked and may lead to undefined behavior.
 // - The ordering of custom substitutions in their files is not important.
-// - Custom substitutions are CaSe-SeNsAtIvE, while built-in substitutions are not.
+// - Custom substitutions are CaSe-SeNsItIvE, while built-in substitutions are not.
 // - Tabs are weird - the amount of whitespace a single tab displays as is based on the position of the text around it (and your text editor).
 //    For best results, use a text editor that lets you visualize the tab character. (if you're using Notepad++, this is View > Show Symbol >
 //    "Show Space and Tabs")


### PR DESCRIPTION
## Text Substitutions v1.1.0

### Major Changes: 
- Added **functional substitutions** - these substitutions take parameters, calculate, and return a value. They are used the same way as normal substitutions; arguments are delimited with a semicolon.
    - `fadd`, `f+`
    - `fsub`, `f-`
    - `fmul`, `f*`
    - `fdiv`, `f/`
    - `fmod`, `f%`
    - `ffloor`
    - `fceil`
    - `fround`
    - `fprefix`, `fpfx`
    - `fsuffix`, `fsfx`
    - `fsubstring`, `fsubstr`
    - `fequals`, `feq`, `f=`
    - `fnotequals`, `fneq`, `f!=`
    - `fgreaterthan`, `fgt`, `f>`
    - `flessthan`, `flt`, `f<`
    - `fgreaterequal`, `fgeq`, `f>=`, `f=>`
    - `flessequal`, `fleq`, `f<=`, `f=<`
    - `fOr`, `f||`
    - `fand`, `f&&`
    - `fnot`, `f!`
    - `fbranch`, `fbch`
    - `fsubstexists`, `fsubexists`, `fexists`, `fsex`
    - `fsafeexecute`, `fsafe`
- All free-text fields in Bridge's IPTC Core metadata section can now be checked for substitutions.
    - Added selector for what fields you want to be checked.
    - The file name can now be checked for substitutions
- Added more builtin substitutions:
    - `mFiletype`, `mExtension` - returns the current file's extension
    - `mRegion` - aliased to `mState`
    - ` ` (empty substitution) - returns an empty string
    - `mSource`
    - `mCaptionWriter`, `mDescWriter`
    - `mCopyrightNotice`, `mCopyright`
    - `mRightsUsageTerms`, `mUsageTerms`
    - `mJobIdentifier`, `mJobIdent`, `mJob`
    - `mInstructions`
    - `mCreator`		
    - `mCreatorJob`	
    - `mCreatorAddress`
    - `mCreatorCity`
    - `mCreatorState`, `mCreatorRegion`, `mCreatorProvince`
    - `mCreatorCountry`
    - `mCreatorPostalCode`, `mCreatorZip`
    - `mCreatorPhone`
    - `mCreatorEmail`
    - `mCreatorWebsite`
- New substitution file - [ts_folderAssignments.txt](substitutions/ts_folderAssignments.txt) - for automatically populating info based on the folder a file is in.
- New substitution file - [ts_hotCodes.txt](substitutions/ts_hotCodes.txt) - replicates PhotoMechanic's Hot Codes feature.

### Minor Changes
- Update the Photo Mechanic Variables custom substitutions file with the new substitutions.
- Typo in ts_customSubs.txt
- Accurized error messages