### PR TITLE
v1.2

### DIFF
--- a/substitutions/ts_photoMechanicVariables.txt
+++ b/substitutions/ts_photoMechanicVariables.txt
@@ -15,6 +15,8 @@ fbas	{mnameshort}
 focallength	{czoom}
 folder	{mfolder}
 fldr	{mfolder}
+foldernum	{fprefix;{mfolder};3}
+fldn	{fprefix;{mfolder};3}
 height	{ch}
 h	{ch}
 y	{ch}
@@ -84,6 +86,7 @@ copyright	{mcopyright}
 copy	{mcopyright}
 source	{msource}
 srce	{msource}
+description	{mdescription}
 
 // TIme & Date	
 ampm	{tampm}
@@ -91,6 +94,7 @@ date	{tdate}
 shot	{tdate}
 day	{tday}
 dow	{tdayp}
+dow3	{fpfx;{tdayp};3}
 hour	{thour12}
 hour24	{thour}
 h24	{thour}
@@ -107,6 +111,7 @@ mnap	{tmonthps}
 second	{tsecond}
 sec	{tsecond}
 time	{ttime}
+
 // Special Variables	
 nl	\n
 	

--- a/substitutions/ts_usefulSubstitutions.txt
+++ b/substitutions/ts_usefulSubstitutions.txt
@@ -1,0 +1,37 @@
+// Some substitutions that may be useful for a variety of purposes
+
+// Plural detector. Returns "1" if the string that's passed in ends with -es or -s but not -is or -ss. "0" otherwise
+ispluralinput	[[mheadline]]
+// ispluralinput   <replace with your input>
+isplural	[[fOr;
+		[[\
+			f=;[[fSfx;[[ispluralinput]];2]];es\
+		]];\
+		[[\
+			f&&;\
+			[[f=;[[fSfx;[[ispluralinput]];1]];s]];\
+			[[f!;[[fAnyEq;[[fSfx;[[ispluralinput]];2]];is;ss]]]]\
+		]]\
+	]]
+
+
+// n-inator - returns "n" if the supplied string starts with a vowel. Intended to be used to turn "a" into "an" when the following word dictates.
+ninatorinput	[[mheadline]]
+// ninatorinput    <replace with your input>
+ninator	[[fBch;\
+		[[fAnyEq;\
+			[[fPfx;[[ninatorinput]];1]];
+			\a;e;i;o;u\
+		]]\
+	;n]]
+
+// an-inator - Returns "a " if the input string is plural or "an " if the input string is plural and starts with a vowel; "" otherwise.
+aninatorinput	[[mheadline]]
+// aninatorinput   <replace with your input>
+aninator	[[fBch;\
+		// plural checker
+		[[f!;[[fOr;[[f=;[[fSfx;[[aninatorinput]];2]];es]];[[f&&;[[f=;[[fSfx;[[aninatorinput]];1]];s]];[[f!;[[fAnyEq;[[fSfx;[[aninatorinput]];2]];is;ss]]]]]]]]]];\
+		// n-inator
+		a[[fBch;[[fAnyEq;[[fPfx;[[aninatorinput]];1]];a;e;i;o;u]];n]]\
+	]]
+

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -693,7 +693,12 @@ function tsBuildSubstitutionTables(){
 		{ target: "flastindexof",		replacement: tsFGetLastIndex				},
 		{ target: "ffindreplace",		replacement: tsFFindReplace					},
 		{ target: "freplace",			replacement: tsFFindReplace					},
-		{ target: "freplace",			replacement: tsFFindReplace					},
+		{ target: "ftouppercase",		replacement: tsFToUpperCase					},
+		{ target: "ftoupper",			replacement: tsFToUpperCase					},
+		{ target: "ftolowercase",		replacement: tsFToLowerCase					},
+		{ target: "ftolower",			replacement: tsFToLowerCase					},
+		{ target: "ftotitlecase",		replacement: tsFToTitleCase					},
+		{ target: "ftotitle",			replacement: tsFToTitleCase					},
 		
 		// logic
 		{ target: "fequals",			replacement: tsFEquals						},
@@ -1841,6 +1846,40 @@ function tsFFindReplace(sel, argv){
 	}
 
 	return s2;
+}
+
+// returns argv[1] in upper case
+function tsFToUpperCase(sel, argv){
+	return argv[1].toUpperCase();
+}
+
+// returns argv[1] in lower case
+function tsFToLowerCase(sel, argv){
+	return argv[1].toLowerCase();
+}
+
+// returns argv[1] in Title Case, following these steps
+/// 1. Capitalize all words
+/// 2. Lowercase the words 'a', 'an', 'and', and 'the'
+/// 3. Capitalize the first and last words
+function tsFToTitleCase(sel, argv){
+	var s = argv[1].split(" ");
+	if(s[0][0]) s[0] = s[0][0].toUpperCase() + s[0].substr(1); // cap first letter;
+	if(s[s.length-1][0]) s[s.length-1] = s[s.length-1][0].toUpperCase()  + s[s.length-1].substr(1); // cap first letter of last word
+
+	for(var i = 1; i < s.length-1; i++){ // go thru all words bewteen the first and last, noninclusive
+		if(s[i] == "a" || s[i] == "an" || s[i] == "the" || s[i] == "and"){ // lowercase all instances of "a", "an", "and", and "the"
+			if(s[i][0]) s[i] = s[i][0].toLowerCase() + s[i].substr(1);
+		}
+		else if(s[i][0]) s[i] = s[i][0].toUpperCase() + s[i].substr(1); // cap all others
+	}
+
+	var r = s[0];
+	for(var i = 1; i < s.length; i++){ // recombine w/ spaces
+		r += " " + s[i];
+	}
+
+	return r;
 }
 
 

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -627,6 +627,8 @@ function tsBuildSubstitutionTables(){
 		{ target: "mcreatorphone",		replacement: tsMCreatorPhone				},
 		{ target: "mcreatoremail",		replacement: tsMCreatorEmail				},
 		{ target: "mcreatorwebsite",	replacement: tsMCreatorWebsite				},
+		{ target: "mdescription",		replacement: tsMDescription					},
+		{ target: "mdesc",				replacement: tsMDescription					},
 		
 
 		// camera-based substitutions
@@ -1571,6 +1573,11 @@ function tsMCreatorPhone(sel){
 	return myXMP.getStructField(XMPConst.NS_IPTC_CORE, "CreatorContactInfo", XMPConst.NS_IPTC_CORE, "CiTelWork");
 }
 
+// returns the Description field
+function tsMDescription(sel){
+	return sel.metadata.read(XMPConst.NS_DC, "description");
+
+}
 
 //////////////////////////
 // CAMERA FUNCTIONS

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -23,8 +23,8 @@ const TS_DELIMITERS = [
 	["=",  "=",  1],
 	["==", "==", 2],
 ]
-const TS_VERSION = "1.1.0";
-const TS_VERSION_PREFS = 100100; // equal to 1.001.00, or 1.1.0
+const TS_VERSION = "1.2.0";
+const TS_VERSION_PREFS = 100200; // equal to 1.002.00, or 1.2.0
 
 var TS_SUB_TABLE_BUILTIN;
 var TS_SUB_TABLE_BUILTIN_FUNCTIONS;
@@ -676,11 +676,23 @@ function tsBuildSubstitutionTables(){
 		{ target: "fsfx",				replacement: tsFSuffix						},
 		{ target: "fsubstring",			replacement: tsFSubstring					},
 		{ target: "fsubstr",			replacement: tsFSubstring					},
+		{ target: "flength",			replacement: tsFLength						},
+		{ target: "flen",				replacement: tsFLength						},
+		{ target: "fgetindex",			replacement: tsFGetIndex					},
+		{ target: "findex",				replacement: tsFGetIndex					},
+		{ target: "findexof",			replacement: tsFGetIndex					},
+		{ target: "fgetlastindex",		replacement: tsFGetLastIndex				},
+		{ target: "flastindex",			replacement: tsFGetLastIndex				},
+		{ target: "flastindexof",		replacement: tsFGetLastIndex				},
+		{ target: "ffindreplace",		replacement: tsFFindReplace					},
+		{ target: "freplace",			replacement: tsFFindReplace					},
 		
 		// logic
 		{ target: "fequals",			replacement: tsFEquals						},
 		{ target: "feq",				replacement: tsFEquals						},
 		{ target: "f=",					replacement: tsFEquals						},
+		{ target: "fanyequals",			replacement: tsFAnyEquals					},
+		{ target: "fanyeq",				replacement: tsFAnyEquals					},
 		{ target: "fnotequals",			replacement: tsFNotEquals					},
 		{ target: "fneq",				replacement: tsFNotEquals					},
 		{ target: "f!=",				replacement: tsFNotEquals					},
@@ -1698,6 +1710,64 @@ function tsFSubstring(sel, argv){
 	return argv[1].substring(argv[2], argv[3]);
 }
 
+// returns the length of argv[1]
+function tsFLength(sel, argv){
+	if(argv[1]) return argv[1].length;
+	return "0";
+}
+
+// string, char, number
+// returns the index of the argv[3]-th occurance of argv[2] in argv[1]. Returns -1 if not found
+function tsFGetIndex(sel, argv){
+	if(argv.length < 3){
+		alert("TextSubstitutions Error:\nfGetIndex in "+ sel.name +" expected 2+ arguments but got " + parseInt(argv.length-1) + "!\n\nThis file has not been affected. No further files will be proccessed.");
+		throw SyntaxError("missingArguments");
+	}
+	if(!argv[3]) argv[3] = 1; // if not defined, assume they want the first one
+
+	var pos = 0;
+	for(var i = 0; i < argv[3]; i++){
+		if(i>0) pos++; // if we aren't on our first go-around, increment the pos so we don't just repeatedly hit the same match
+		pos = argv[1].indexOf(argv[2], pos);
+	}
+
+	return pos;
+}
+
+// returns the index of the argv[3]-th occurance of argv[2] in argv[1], counting from the end. Returns -1 if not found
+function tsFGetLastIndex(sel, argv){
+	if(argv.length < 3){
+		alert("TextSubstitutions Error:\nfGetIndex in "+ sel.name +" expected 2+ arguments but got " + parseInt(argv.length-1) + "!\n\nThis file has not been affected. No further files will be proccessed.");
+		throw SyntaxError("missingArguments");
+	}
+	if(!argv[3]) argv[3] = 1; // if not defined, assume they want the first one
+
+	var pos = argv[1].length;
+	for(var i = 0; i < argv[3]; i++){
+		if(i>0) pos--; // if we aren't on our first go-around, decrement the pos so we don't just repeatedly hit the same match
+		pos = argv[1].lastIndexOf(argv[2], pos);
+	}
+
+	return pos;
+}
+
+// replaces all instances of argv[2] in argv[1] with argv[3]
+function tsFFindReplace(sel, argv){
+	if(argv.length < 3){
+		alert("TextSubstitutions Error:\nfFindReplace in "+ sel.name +" expected 2+ arguments but got " + parseInt(argv.length-1) + "!\n\nThis file has not been affected. No further files will be proccessed.");
+		throw SyntaxError("missingArguments");
+	}
+
+	if(!argv[3]) argv[3] = ""; // default to blank if not provided
+	var s1 = argv[1].split(argv[2]);
+	var s2 = s1[0];
+
+	for(var i = 1; i < s1.length; i++){
+		s2 = s2 + argv[3] + s1[i]; // concat with the separator character between
+	}
+
+	return s2;
+}
 
 
 
@@ -1714,6 +1784,17 @@ function tsFEquals(sel, argv){
 	}
 
 	return "1";
+}
+
+// returns "1" if argv[1] equals any argv[2+], "0" otherwise
+function tsFAnyEquals(sel, argv){
+	if(argv.length <= 2) return "0";
+
+	for(var i = 2; i < argv.length; i++){
+		if(argv[1] == argv[i]) return "1";
+	}
+
+	return "0";
 }
 
 // returns "1" if any argv[1+] are different, "0" otherwise

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -382,10 +382,6 @@ function tsPrefsPanel(){
 			var statictext8 = panelPropertyCategories.add("statictext", undefined, undefined, {name: "statictext8", multiline: true}); 
     		statictext8.text = "Only these fields will be checked for custom substitutions when the program is run. Reducing the number of fields analyzed will improve performance. Only fields in IPTC Core (not IPTC Extension) are analyzed."; 
 
-			var cbPropCatFilename = panelPropertyCategories.add("checkbox", undefined, undefined, {name: "cbPropCatFilename"}); 
-				cbPropCatFilename.helpTip = "The file's filename. Use caution\nwhen changing file extensions."; 
-				cbPropCatFilename.text = "Filename"; 
-
 			var cbPropCatCore = panelPropertyCategories.add("checkbox", undefined, undefined, {name: "cbPropCatCore"}); 
 				cbPropCatCore.helpTip = "Description, keywords, alt-text, extended description,\nheadline, title, sublocation, city, state, country, and country code."; 
 				cbPropCatCore.text = "Core"; 
@@ -397,6 +393,10 @@ function tsPrefsPanel(){
 			var cbPropCatMisc = panelPropertyCategories.add("checkbox", undefined, undefined, {name: "cbPropCatMisc"}); 
 				cbPropCatMisc.helpTip = "IPTC subject & scene codes, intellectual genre,\njob identifier, and instructions."; 
 				cbPropCatMisc.text = "Misc"; 
+
+			var cbPropCatFilename = panelPropertyCategories.add("checkbox", undefined, undefined, {name: "cbPropCatFilename"}); 
+				cbPropCatFilename.helpTip = "The file's filename. Use caution\nwhen changing file extensions."; 
+				cbPropCatFilename.text = "Filename"; 
 
 				// initalize delimiter values
 				if(app.preferences.tsPropertyCategories & TS_PROPERTY_CATEGORIES.filename){

--- a/textSubstitutions.jsx
+++ b/textSubstitutions.jsx
@@ -545,6 +545,8 @@ function tsBuildSubstitutionTables(){
 		{ target: "tday",				replacement: tsTDateTakenDay				},
 		{ target: "tdayp",				replacement: tsTDateTakenDayPretty			},
 		{ target: "tdaypretty",			replacement: tsTDateTakenDayPretty			},
+		{ target: "tdayofweek",			replacement: tsTDateTakenDayPretty			},
+		{ target: "tdow",				replacement: tsTDateTakenDayPretty			},
 		{ target: "tmonth",				replacement: tsTDateTakenMonth				},
 		{ target: "tmonthp",			replacement: tsTDateTakenMonthPretty		},
 		{ target: "tmonthpretty",		replacement: tsTDateTakenMonthPretty		},
@@ -688,6 +690,7 @@ function tsBuildSubstitutionTables(){
 		{ target: "flastindex",			replacement: tsFGetLastIndex				},
 		{ target: "flastindexof",		replacement: tsFGetLastIndex				},
 		{ target: "ffindreplace",		replacement: tsFFindReplace					},
+		{ target: "freplace",			replacement: tsFFindReplace					},
 		{ target: "freplace",			replacement: tsFFindReplace					},
 		
 		// logic


### PR DESCRIPTION
## Text Substitutions v1.2.0

### Major Changes: 
- Added new fuctional substitutions: 
    - `fLength`, `fLen`
    - `fGetIndex`, `fIndex`, `fIndexOf`
    - `fGetLastIndex`. `fLastIndex`, `fLastIndexOf`
    - `fFindReplace`, `fReplace`
    - `fToUpperCase`, `fToUpper`
    - `fToLowerCase`, `fToLower`
    - `fToTitleCase`, `fToTitle`
    - `fAnyEquals`, `fAnyEq`
- Added new builtin substitutions:
    - `mDescription`, `mDesc`
    - `tDOW`, `tDayOfWeek` (aliases for `tDayP`)
- Changes to already-loaded custom substitution files are now detected and **automatically reloaded** when the script is run - no more need to open the settings and click the reload button!
- Added support for **multi-line substitution definitions** - in a custom substitution file, ending a substitution definition with a backslash (`\`) will ignore the following newline and continue reading the substitution definition on the next line.
    - Leading tabs on the following line will be ignored.
    - If the following line is commented out or only contains tabs, it will be ignored and the next line will be used. 
- New substitution file - [ts_usefulSubstitutions.txt](substitutions/ts_UsefulSubstitutions.txt) containing some useful custom substitutions for advanced work (for detecting plurals and leading vowels)

### Minor Changes
- Update the Photo Mechanic Variables custom substitutions file with the new substitutions.
- Cosmetic changes to the settings panel