### PR TITLE
SP + SF + CM Metadata and small tweaks

### DIFF
--- a/copyMetadata.jsx
+++ b/copyMetadata.jsx
@@ -1,10 +1,22 @@
 ﻿/*
+@@@START_XML@@@
+<?xml version="1.0" encoding="UTF-8"?>
+<ScriptInfo xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en_US">
+<dc:title>Copy Metadata</dc:title>
+<dc:description>This script allows copying some metadata between files. Activated from the Tools or Context (right-click) menus.</dc:description>
+<dc:source>https://github.com/9yz/bridge-scripts</dc:source>
+@@@END_XML@@
+*/
 
-	copyMetadataCont Script created by 9yz
-	12/08/24
+/*
+
+	copyMetadata.jsx
 
 	Adds the ability to copy IPTC metadata between files.
-	Activate via Tools > Copy Property or Tools > Paste Property..
+	Activate via Tools > Copy Property or Tools > Paste Property...
+
+	See repo for documentation:
+	https://github.com/9yz/bridge-scripts
 
 */
 

--- a/copyMetadata.jsx
+++ b/copyMetadata.jsx
@@ -86,7 +86,7 @@ if(BridgeTalk.appName == 'bridge'){
 
 	}
 	catch(e){
-		alert("Copy Metadata Error:\n" + e + ' ' + e.line);
+		alert("Copy Metadata error:\n" + e + ' ' + e.line);
 	}
 }
 
@@ -297,19 +297,19 @@ function cmCopy(){
 
 		var selection = app.document.selections; // get selected files
 		if(!selection.length){ // nothing selected
-			alert('Copy Metadata Error:\nNothing selected!');
+			alert('Copy Metadata error:\nNothing selected!');
 			return;
 		}
 		if(selection.length > 1){ // more than 1 selected
-			alert('Copy Metadata Error:\nYou can only copy from one file at a time.'); 
+			alert('Copy Metadata error:\nYou can only copy from one file at a time.'); 
 			return;
 		} 
 		if(selection[0].container){ // selection is a folder
-			alert('Copy Metadata Error:\nFolders cannot be copied from.');
+			alert('Copy Metadata error:\nFolders cannot be copied from.');
 			return;
 		}
 		if(!selection[0].synchronousMetadata){ // selection doesn't support xmp
-			alert('Copy Metadata Error:\nThis file does not have XMP metadata.');
+			alert('Copy Metadata error:\nThis file does not have XMP metadata.');
 			return;
 		}
 		
@@ -357,7 +357,7 @@ function cmCopy(){
 		app.synchronousMode = false;
 	}
 	catch(e){
-		alert("Copy Metadata Error:\n" + e + ' ' + e.line);
+		alert("Copy Metadata error:\n" + e + ' ' + e.line);
 	}
 }
 
@@ -369,7 +369,7 @@ function cmPaste(method){
 		var errorFiles = 0;
 		var selection = app.document.selections; // get selected files
 		if(!selection.length){ // nothing selected
-			alert('Copy Metadata Error:\nNothing selected!');
+			alert('Copy Metadata error:\nNothing selected!');
 			return;
 		} 
 
@@ -444,14 +444,14 @@ function cmPaste(method){
 		}
 
 		if(errorFiles > 0){
-			alert("Copy Metadata Error:\n" + errorFiles + " files were not processed because they do not support metadata.")
+			alert("Copy Metadata error:\n" + errorFiles + " files were not processed because they do not support metadata.")
 		}
 
 
 		app.synchronousMode = false;
 	}
 	catch(e){
-		alert("Copy Metadata Error:\n" + e + ' ' + e.line);
+		alert("Copy Metadata error:\n" + e + ' ' + e.line);
 	}
 }
 

--- a/scratchPad.jsx
+++ b/scratchPad.jsx
@@ -24,29 +24,14 @@
 
 
 #target bridge
+
 // STARTUP FUNCTION: run when bridge starts, used for setup
 if(BridgeTalk.appName == 'bridge'){ 
 	try{
-
-		// Load the XMP Script library
-		if( xmpLib == undefined ){
-			if(Folder.fs == "Windows"){
-				var pathToLib = Folder.startup.fsName + "/AdobeXMPScript.dll";
-			} 
-			else {
-				var pathToLib = Folder.startup.fsName + "/AdobeXMPScript.framework";
-			}
-		
-			var libfile = new File( pathToLib );
-			var xmpLib = new ExternalObject("lib:" + pathToLib );
-		}
-
-		var spMenuRun 			= MenuElement.create('command', 'Scratch Pad', 'at the beginning of Window-');
-		// var spMenuRun 			= MenuElement.create('command', 'Scratch Pad', 'at the beginning of Window');
-
+		var spMenuRun = MenuElement.create('command', 'Scratch Pad', 'at the beginning of Window-');
 	}
 	catch(e){
-		alert(e + ' ' + e.line);
+		alert("ScratchPad error:\n" + e + ' ' + e.line);
 	}
 }
 
@@ -58,8 +43,6 @@ spMenuRun.onSelect = function(){
 
 function spCreateWindow(){
 	try{
-
-		// why this code works and 
 		
 		this.paletteRefs = new Array();
 		var spWrapper = this;
@@ -89,6 +72,6 @@ function spCreateWindow(){
 
 
 	} catch(e){
-        alert(e + ' ' + e.line);
+        alert("ScratchPad error:\n" + e + ' ' + e.line);
     }
 }

--- a/scratchPad.jsx
+++ b/scratchPad.jsx
@@ -1,12 +1,24 @@
+/*
+@@@START_XML@@@
+<?xml version="1.0" encoding="UTF-8"?>
+<ScriptInfo xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en_US">
+<dc:title>Scratch Pad</dc:title>
+<dc:description>Adds a new "Scratch Pad" window for taking notes or whatever. Accessed through Window > Scratch Pad.</dc:description>
+<dc:source>https://github.com/9yz/bridge-scripts</dc:source>
+@@@END_XML@@
+*/
+
 /* 
 	
 	scratchPad.jsx
-	12/08/24
 
 	Adds a new "Scratch Pad" window for taking notes or whatever. Accessed through Window > Scratch Pad.
 	Text is not saved between sessions.
 
 	Derived from TextPreview.jsx by David M. Converse, availible under the Apache 2.0 License.
+
+	See repo for documentation:
+	https://github.com/9yz/bridge-scripts
 
 */
 

--- a/scriptFramework.jsx
+++ b/scriptFramework.jsx
@@ -1,6 +1,25 @@
-// Sample script intended for developers to build off of.
+/*
+@@@START_XML@@@
+<?xml version="1.0" encoding="UTF-8"?>
+<ScriptInfo xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en_US">
+<dc:title>Script Name</dc:title>
+<dc:description>The text here is displayed in Bridge's Startup Script listing and defined in the header of the script file.</dc:description>
+<dc:source>This field is not displayed in Bridge but is suggested as a helpful include in Adobe's documentation.</dc:source>
+@@@END_XML@@
+*/
 
-// for ESTK
+// The above block defines metadata for the script; it is used by Bridge in the listing for Startup Scripts in the preferences window.
+
+/* 
+
+	scriptFramework.jsx
+
+	A simple framework for developers to builf off of.
+
+*/
+
+
+// for the ExtendScript ToolKit (ESTK)
 #target bridge 
 
 // STARTUP FUNCTION: run when bridge starts, used for setup
@@ -13,7 +32,6 @@ if(BridgeTalk.appName == 'bridge'){
 		} 
 		else { // run only on mac
 			if( xmpLib == undefined ) var pathToLib = Folder.startup.fsName + "/AdobeXMPScript.framework"; // Load the XMP Script library
-
 		}
 
 
@@ -35,7 +53,7 @@ if(BridgeTalk.appName == 'bridge'){
 
 
 	} catch(e){
-		alert("Script Error:\n" + e + ' ' + e.line);
+		alert("Script error:\n" + e + ' ' + e.line);
 	}
 }
 
@@ -67,7 +85,7 @@ function alertDescriptions(){
 
 		var selection = app.document.selections; // get selected files
 		if(selection.length == 0){ // check for empty selection
-			alert("Nothing selected!")
+			alert("Nothing selected!");
 			return;
 		}
 
@@ -83,6 +101,6 @@ function alertDescriptions(){
 
 		app.synchronousMode = false;
 	} catch(e){
-		alert("Script Error:\n" + e + ' ' + e.line);
+		alert("Script error:\n" + e + ' ' + e.line);
 	}
 }


### PR DESCRIPTION
- Added metadata to Copy Metadata, Scratch Pad, and the Script Framework for Bridge to use in its listing of scripts.
- Removed useless code and comments from Scratch Pad
- Made descriptive headers consistent across files to point back to this repo
- Made capitalization of error messages consistent across files
- Script names now have spaces in them when shown to user (rather than in filenames)